### PR TITLE
Fix kibana exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY run /etc/service/kibana/
 
 WORKDIR /opt/kibana
 
-EXPOSE 80
+EXPOSE 5601
 
 CMD ["/sbin/my_init"]
 


### PR DESCRIPTION
wrong exposed port kibana is running on port 5601, this make some problem with services reading exposed ports.
