### PR TITLE
update elasticsearch container version to 1.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Version 1.1
 
-FROM devdb/elasticsearch:1.4.2
+FROM devdb/elasticsearch:1.4.4
 
 MAINTAINER Abhinav Ajgaonkar <abhinav316@gmail.com>
 


### PR DESCRIPTION
kimbana 4.0.0 now requires elasticsearch 1.4.4
